### PR TITLE
Fix funny baud rate, add proper platformio.ini, external DAC functionality

### DIFF
--- a/examples/esp32_adc_lut_example.ino
+++ b/examples/esp32_adc_lut_example.ino
@@ -285,7 +285,7 @@ void setup() {
     dac_output_enable(DAC_CHANNEL_1);        // Enable DAC on pin 25
     dac_output_voltage(DAC_CHANNEL_1, 0);    // Setup output voltage to 0
     analogReadResolution(12);
-    Serial.begin(500000);
+    Serial.begin(460800);
     while (!Serial) {}
 }
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,4 +1,4 @@
-;PlatformIO Project Configuration File
+; PlatformIO Project Configuration File
 ;
 ;   Build options: build flags, source filter
 ;   Upload options: custom upload port, speed and extra flags
@@ -8,7 +8,14 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env:esp-wrover-kit]
+[env]
+monitor_speed = 460800
 platform = espressif32
-board = esp32dev
 framework = arduino
+
+[env:heltec-wifi-lora-v3]
+board = heltec_wifi_lora_32_V3
+lib_deps = adafruit/Adafruit MCP4725@^2.0.2
+
+[env:esp-wrover-kit]
+board = esp32dev

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,20 +1,49 @@
+#define EXT_DAC     //comment this out if you aren't using an ESP32-S3
+
 #include <Arduino.h>
-#include <driver/dac.h>
+#ifndef EXT_DAC
+#include <driver/dac.h> //esp32-s3 doesn't have a DAC!!
+#else
+#include <Wire.h>
+#include <Adafruit_MCP4725.h>
+#endif
 
 // Based on original work from Helmut Weber (https://github.com/MacLeod-D/ESP32-ADC)
 // that he described at https://esp32.com/viewtopic.php?f=19&t=2881&start=30#p47663
 // Modified with bug-fixed by Henry Cheung
+// Add External DAC for ESP32-S3 and Teleplot functionality by bitrot_alpha
 //
 // Build a ESP32 ADC Lookup table to correct ESP32 ADC linearity issue
 // Run this sketch to build your own LUT for each of your ESP32, copy and paste the
 // generated LUT to your sketch for using it, see example sketch on how to use it
 //
+// Version 2.1 - fix some oddities, improve graphing using Teleplot
 // Version 2.0 - switch to use analogRead() instead of esp-idf function adcStart()
 // Version 1.0 - original adoptation and bug fix based on Helmut Weber code
 
-// #define GRAPH      // uncomment this for print on Serial Plotter
-#define FLOAT_LUT     // uncomment this if you need float LUT
-#define ADC_PIN 35    // GPIO 35 = A7, uses any valid Ax pin as you wish
+//#define GRAPH      // uncomment this for print on Serial Plotter
+//#define FLOAT_LUT     // uncomment this if you need float LUT
+
+// Graphing with Teleplot
+/*
+    Please open Teleplot on PlatformIO before running the program.
+    Alien->Quick Access->Miscellaneous->Serial & UDP Plotter
+    Settings: your COM/tty port for ESP32, baud 460800
+    Press the round blue button with the "<" to open serial log.
+    Once the onboard LED on the ESP32 dev board illuminates, graph data is ready.
+    Press BOOT/PRG button on the board to begin output.
+*/
+
+#ifdef EXT_DAC
+#define ADC_PIN 2    
+#define SDA_PIN 39
+#define SCL_PIN 40
+#define EXT_DAC_ADDR 0x60
+#else
+#define ADC_PIN 35  // GPIO 35 = A7, uses any valid Ax pin as you wish
+#endif
+
+Adafruit_MCP4725 dac_ext;
 
 float Results[4097];
 float Res2[4096*5];
@@ -42,10 +71,25 @@ void dumpRes2() {
 }
 
 void setup() {
+    #ifndef EXT_DAC
     dac_output_enable(DAC_CHANNEL_1);    // pin 25
+
     dac_output_voltage(DAC_CHANNEL_1, 0);
+    #endif
+    Serial.begin(460800);
+    #ifdef EXT_DAC
+    Wire1.begin(SDA_PIN, SCL_PIN);
+    if (!dac_ext.begin(EXT_DAC_ADDR, &Wire1))
+    {
+      while(1)
+      {
+        Serial.println("MCP4725 not found! Check wiring and I2C address.");
+        delay(1500);
+      }
+    }
+    dac_ext.setVoltage(0, false);
+    #endif
     analogReadResolution(12);
-    Serial.begin(500000);
     delay(1000);
 }
 
@@ -55,7 +99,11 @@ void loop() {
     for (int j=0; j<500; j++) {
       if (j % 100 == 0) Serial.print(".");
       for (int i=0;i<256;i++) {
+          #ifndef EXT_DAC
           dac_output_voltage(DAC_CHANNEL_1, (i & 0xff));
+          #else
+          dac_ext.setVoltage( ( (i & 0xFF) << 4 ) + 0xf, false);
+          #endif
           delayMicroseconds(100);
           Results[i*16]=0.9*Results[i*16] + 0.1*analogRead(ADC_PIN);
       }
@@ -105,14 +153,34 @@ void loop() {
     }
 
 #ifdef GRAPH
-
-    while(1) {
+    //indicate that we're ready to output graph data
+    pinMode(LED_BUILTIN, OUTPUT);
+    digitalWrite(LED_BUILTIN, 1);
+    pinMode(GPIO_NUM_0, INPUT_PULLUP);
+    Serial.println("Press PRG/BOOT button on ESP32 to graph!");
+    while(digitalRead(GPIO_NUM_0))
+    {
+      delay(125);
+    }
+    digitalWrite(LED_BUILTIN, 0);
+    
+    //while(1) {
+    float r;
       for (int i=2; i<256; i++) {
+        #ifndef EXT_DAC
         dac_output_voltage(DAC_CHANNEL_1, (i & 0xff));
+        #else
+        dac_ext.setVoltage( ( (i & 0xff) << 4) + 0xf, false);
+        #endif
         delayMicroseconds(100);
-        float r = Results[analogRead(ADC_PIN)];
-        Serial.print(i*16); Serial.print(" "); Serial.println(r);
+        //Serial.print(i*16); Serial.print(" "); Serial.println(r);
+        r = Results[analogRead(ADC_PIN)];
+        Serial.printf(">volt:%d\n>ADC:%f\n", (i*16), r);
       }
+    //}
+    while (1)
+    {
+      delay(125);
     }
 
 #else

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,11 +39,11 @@
 #define SDA_PIN 39
 #define SCL_PIN 40
 #define EXT_DAC_ADDR 0x60
+Adafruit_MCP4725 dac_ext;
 #else
 #define ADC_PIN 35  // GPIO 35 = A7, uses any valid Ax pin as you wish
 #endif
 
-Adafruit_MCP4725 dac_ext;
 
 float Results[4097];
 float Res2[4096*5];
@@ -170,7 +170,7 @@ void loop() {
         #ifndef EXT_DAC
         dac_output_voltage(DAC_CHANNEL_1, (i & 0xff));
         #else
-        dac_ext.setVoltage( ( (i & 0xff) << 4) + 0xf, false);
+        dac_ext.setVoltage( ( (i & 0xff) << 4) | 0xf, false);
         #endif
         delayMicroseconds(100);
         //Serial.print(i*16); Serial.print(" "); Serial.println(r);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -102,7 +102,7 @@ void loop() {
           #ifndef EXT_DAC
           dac_output_voltage(DAC_CHANNEL_1, (i & 0xff));
           #else
-          dac_ext.setVoltage( ( (i & 0xFF) << 4 ) + 0xf, false);
+          dac_ext.setVoltage( ( (i & 0xFF) << 4 ) | 0xf, false);
           #endif
           delayMicroseconds(100);
           Results[i*16]=0.9*Results[i*16] + 0.1*analogRead(ADC_PIN);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -165,8 +165,8 @@ void loop() {
     digitalWrite(LED_BUILTIN, 0);
     
     //while(1) {
-    float r;
-      for (int i=2; i<256; i++) {
+    unsigned int r;
+      for (int i=0; i<256; i++) {
         #ifndef EXT_DAC
         dac_output_voltage(DAC_CHANNEL_1, (i & 0xff));
         #else
@@ -175,7 +175,7 @@ void loop() {
         delayMicroseconds(100);
         //Serial.print(i*16); Serial.print(" "); Serial.println(r);
         r = Results[analogRead(ADC_PIN)];
-        Serial.printf(">volt:%d\n>ADC:%f\n", (i*16), r);
+        Serial.printf(">out (DAC):%d\n>in (ADC):%d\n", (i*16), r);
       }
     //}
     while (1)


### PR DESCRIPTION
Plotting/graphing didn't work for me and I was trying to calibrate an ESP32-S3 which doesn't have an internal DAC. I used an MCP4725 (12-bit DAC) since that's what I had laying around. I don't know if my method to "convert" the MCP4725 to an 8-bit DAC by just left-shifting 4 and adding 0xF is the best way, but it seemed to work fine looking at the output.

Regular ESP32 the program still works (mostly) the same. Just comment out the first line, `#define EXT_DAC`.

Modern PlatformIO uses Teleplot for plotting, so I changed the output to conform to Teleplot's guidelines. I got rid of the infinite looping when trying to plot. Program now waits for a button press before sending plot data.